### PR TITLE
Handle newline in views

### DIFF
--- a/resources/views/basemenu.dt
+++ b/resources/views/basemenu.dt
@@ -1,5 +1,5 @@
 div(class="menu", id="menu")
   a(class="menuitem", href="index") Startseite
   a(class="menuitem", href="add") Hinzufügen
-  a(class="menuitem", href="all") Alle
+  a(class="menuitem", href="all_paginated?pagesize=10&page=1") Alle
   a(class="menuitem", href="random") Zufällig

--- a/resources/views/modify.dt
+++ b/resources/views/modify.dt
@@ -2,7 +2,6 @@ extends ./layout
 
 block content
   p#desc Zitat bearbeiten.
-  p Zeilenumbrüche werden ersetzt durch „ – “.
   form(action="do_modify", method="POST")
     div Zitat:
     textarea#inputField(type="text", name="cite", autofocus=true) #{citetext}

--- a/resources/views/rendercite.dt
+++ b/resources/views/rendercite.dt
@@ -1,7 +1,8 @@
 div.citecontainer
   a.citeid(href="cite?id=#{cite.id}") #{cite.id}
   div.cite
-    div.citetext #{cite.cite}
+    - import std.string :replace;
+    div.citetext #{cite.cite.replace("\r\n", " – ")}
       a.edit(href="modify?id=#{cite.id}") (Edit)
     div.added Added by #{cite.addedby} (#{cite.added})
     div.changed Last changed by #{cite.changedby} (#{cite.changed})


### PR DESCRIPTION
When looking at cites, newline (`\r\n`) dont get shown at all, even though they're there.
This fixes both #36 and #37 by replacing `\r\n` with ` – `.